### PR TITLE
Use HAProxy location for the host header

### DIFF
--- a/AppServer/google/appengine/tools/devappserver2/module.py
+++ b/AppServer/google/appengine/tools/devappserver2/module.py
@@ -581,7 +581,7 @@ class Module(object):
     try:
       environ['SERVER_PORT'] = environ['HTTP_HOST'].split(':')[1]
     except IndexError:
-      scheme = environ['HTTP_X_FORWARDED_PROTO']
+      scheme = environ.get('HTTP_X_FORWARDED_PROTO', 'http')
       if scheme == 'http':
         environ['SERVER_PORT'] = 80
       else:


### PR DESCRIPTION
Since the host header defines which service the push task goes to in App Engine, this roughly preserves the same behavior (since the target service has already been selected at this point). There are some edge cases (especially during service relocation) where this behaves differently, but the routing pieces need more work to support those differences.